### PR TITLE
Fix potential use of uninitialized variable.

### DIFF
--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -5424,7 +5424,7 @@ static u8 fuzz_one(char** argv) {
   u8 skip_simple_bitflip = 0;
   u8 * virgin_virgin_bits = 0;
   char * shadow_prefix = "";
-  u32 * position_map;
+  u32 * position_map = NULL;
   u32 orig_queued_with_cov = queued_with_cov;
   u32 orig_queued_discovered = queued_discovered;
   u32 orig_total_execs = total_execs;


### PR DESCRIPTION
It appears in some cases control might jump to the end of `fuzz_one` via the `abandon_entry` label, where it gets freed, prior to `position_map` initialization. Setting it to `NULL` turns this into a harmless `free(NULL)`. Might manifest as a double free in some cases, probably due to reuse of old stack space in a subsequent call.

I catched this by compiling afl with ASAN, which gave the following report when it crashed:

    ==8432==ERROR: AddressSanitizer: attempting double-free on 0x9951d440 in thread T0:
        #0 0x56705605 in __interceptor_free.localalias.0 (/home/dkasak/code/projects/afl-rb/afl-fuzz+0xe6605)
        #1 0x5676f5d5 in fuzz_one /home/dkasak/code/projects/afl-rb/afl-fuzz.c:7595:3
        #2 0x5674631b in main /home/dkasak/code/projects/afl-rb/afl-fuzz.c:9068:20
        #3 0xf74157c2 in __libc_start_main (/usr/lib32/libc.so.6+0x187c2)
        #4 0x5663e0a5 in _start (/home/dkasak/code/projects/afl-rb/afl-fuzz+0x1f0a5)
    
    0x9951d440 is located 0 bytes inside of 448-byte region [0x9951d440,0x9951d600)
    freed by thread T0 here:
        #0 0x56705605 in __interceptor_free.localalias.0 (/home/dkasak/code/projects/afl-rb/afl-fuzz+0xe6605)
        #1 0x5676f5d5 in fuzz_one /home/dkasak/code/projects/afl-rb/afl-fuzz.c:7595:3
        #2 0x5674631b in main /home/dkasak/code/projects/afl-rb/afl-fuzz.c:9068:20
        #3 0xf74157c2 in __libc_start_main (/usr/lib32/libc.so.6+0x187c2)
    
    previously allocated by thread T0 here:
        #0 0x567057cd in malloc (/home/dkasak/code/projects/afl-rb/afl-fuzz+0xe67cd)
        #1 0x5676dd09 in fuzz_one /home/dkasak/code/projects/afl-rb/afl-fuzz.c:7420:22
        #2 0x5674631b in main /home/dkasak/code/projects/afl-rb/afl-fuzz.c:9068:20
        #3 0xf74157c2 in __libc_start_main (/usr/lib32/libc.so.6+0x187c2)