### PR TITLE
Some memory allocation changes.

### DIFF
--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -3053,8 +3053,6 @@ static void perform_dry_run(char** argv) {
 
     res = calibrate_case(argv, q, use_mem, 0, 1);
 
-    ck_free(q->trace_mini);
-    ck_free(q->fuzzed_branches);
     // @RB@ added these for every queue entry
     // free what was added in add_to_queue
     ck_free(q->trace_mini);

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -7262,9 +7262,9 @@ havoc_stage:
 
             temp_len += clone_len;
 
-            free(position_map);
-            position_map =malloc(sizeof(u32)*(temp_len+1));
-
+            position_map = realloc(position_map, sizeof (u32) * (temp_len + 1));
+            if (!position_map)
+              PFATAL("Failure resizing position_map.\n");
           }
 
           break;
@@ -7406,8 +7406,9 @@ havoc_stage:
             out_buf   = new_buf;
             temp_len += extra_len;
 
-            free(position_map);
-            position_map = malloc(sizeof(u32)*(temp_len + 1));
+            position_map = realloc(position_map, sizeof (u32) * (temp_len + 1));
+            if (!position_map)
+              PFATAL("Failure resizing position_map.\n");
 
             break;
 
@@ -7425,8 +7426,9 @@ havoc_stage:
     if (temp_len < len) {
       out_buf = ck_realloc(out_buf, len);
       branch_mask = ck_realloc(branch_mask, len + 1);
-      free(position_map);
-      position_map = malloc(sizeof(u32)*(len+1));
+      position_map = realloc(position_map, sizeof (u32) * (len + 1));
+      if (!position_map)
+        PFATAL("Failure resizing position_map.\n");
     }
     temp_len = len;
     memcpy(out_buf, in_buf, len);
@@ -7559,8 +7561,9 @@ retry_splicing:
     orig_branch_mask = ck_alloc(len +1);
     //ck_realloc(orig_branch_mask, len + 1);
     memcpy (orig_branch_mask, branch_mask, len + 1);
-    free(position_map);
-    position_map = malloc(sizeof(u32)*(len+1));
+    position_map = realloc(position_map, sizeof (u32) * (len + 1));
+    if (!position_map)
+      PFATAL("Failure resizing position_map.\n");
 
     goto havoc_stage;
 

--- a/afl-fuzz.c
+++ b/afl-fuzz.c
@@ -893,7 +893,7 @@ static int contains_id(int branch_id, int* branch_ids){
 
 /* you'll have to free the return pointer. */
 static int* get_lowest_hit_branch_ids(){
-  int * rare_branch_ids = malloc(sizeof(int)*MAX_RARE_BRANCHES);
+  int * rare_branch_ids = ck_alloc(sizeof(int) * MAX_RARE_BRANCHES);
   int lowest_hob = INT_MAX;
   int ret_list_size = 0;
 
@@ -927,7 +927,7 @@ static int* get_lowest_hit_branch_ids(){
     if (lowest_hob != INT_MAX) {
       rare_branch_exp = lowest_hob + 1;
       DEBUG1("Upped max exp to %i\n", rare_branch_exp);
-      free(rare_branch_ids);
+      ck_free(rare_branch_ids);
       return get_lowest_hit_branch_ids();
     }
   }
@@ -992,7 +992,7 @@ static u32 * is_rb_hit_mini(u8* trace_bits_mini){
 
   }
   ck_free(branch_cts);
-  free(rarest_branches);
+  ck_free(rarest_branches);
   if (min_hit_index == 0){
       ck_free(branch_ids);
       branch_ids = NULL;
@@ -5560,7 +5560,7 @@ static u8 fuzz_one(char** argv) {
 
 
     DEBUG1("which hit branch %i (hit by %u inputs) \n", rb_fuzzing -1, hit_bits[rb_fuzzing -1]);
-    //free(rarest_branches);
+    //ck_free(rarest_branches);
    
     }
   }
@@ -5719,7 +5719,7 @@ re_run: // re-run when running in shadow mode
   }
   // this will be used to store the valid modifiable positions
   // in the havoc stage. malloc'ing once to reduce overhead. 
-  position_map = malloc(sizeof(u32)*(len+1));
+  position_map = ck_alloc(sizeof(u32) * (len+1));
 
   /* Skip right away if -d is given, if we have done deterministic fuzzing on
      this entry ourselves (was_fuzzed), or if it has gone through deterministic
@@ -6016,7 +6016,7 @@ skip_simple_bitflip:
     if (blacklist_pos >= blacklist_size -1){
       DEBUG1("Increasing size of blacklist from %d to %d\n", blacklist_size, blacklist_size*2);
       blacklist_size = 2 * blacklist_size; 
-      blacklist = realloc(blacklist, sizeof(int)* blacklist_size);
+      blacklist = ck_realloc(blacklist, sizeof(int) * blacklist_size);
       if (!blacklist){
         PFATAL("Failed to realloc blacklist");
       }
@@ -7262,7 +7262,7 @@ havoc_stage:
 
             temp_len += clone_len;
 
-            position_map = realloc(position_map, sizeof (u32) * (temp_len + 1));
+            position_map = ck_realloc(position_map, sizeof (u32) * (temp_len + 1));
             if (!position_map)
               PFATAL("Failure resizing position_map.\n");
           }
@@ -7406,7 +7406,7 @@ havoc_stage:
             out_buf   = new_buf;
             temp_len += extra_len;
 
-            position_map = realloc(position_map, sizeof (u32) * (temp_len + 1));
+            position_map = ck_realloc(position_map, sizeof (u32) * (temp_len + 1));
             if (!position_map)
               PFATAL("Failure resizing position_map.\n");
 
@@ -7426,7 +7426,7 @@ havoc_stage:
     if (temp_len < len) {
       out_buf = ck_realloc(out_buf, len);
       branch_mask = ck_realloc(branch_mask, len + 1);
-      position_map = realloc(position_map, sizeof (u32) * (len + 1));
+      position_map = ck_realloc(position_map, sizeof (u32) * (len + 1));
       if (!position_map)
         PFATAL("Failure resizing position_map.\n");
     }
@@ -7561,7 +7561,7 @@ retry_splicing:
     orig_branch_mask = ck_alloc(len +1);
     //ck_realloc(orig_branch_mask, len + 1);
     memcpy (orig_branch_mask, branch_mask, len + 1);
-    position_map = realloc(position_map, sizeof (u32) * (len + 1));
+    position_map = ck_realloc(position_map, sizeof (u32) * (len + 1));
     if (!position_map)
       PFATAL("Failure resizing position_map.\n");
 
@@ -7604,7 +7604,7 @@ abandon_entry:
 
   if (in_buf != orig_in) ck_free(in_buf);
 
-  free(position_map);
+  ck_free(position_map);
   ck_free(out_buf);
   ck_free(eff_map);
   ck_free(branch_mask);
@@ -8714,7 +8714,7 @@ int main(int argc, char** argv) {
   u8  exit_1 = !!getenv("AFL_BENCH_JUST_ONE");
   char** use_argv;
 
-  blacklist = malloc(sizeof(int)* blacklist_size);
+  blacklist = ck_alloc(sizeof(int) * blacklist_size);
   blacklist[0] = -1;
 
   struct timeval tv;
@@ -9116,7 +9116,7 @@ stop_fuzzing:
 
   dump_to_logs();
   fclose(plot_file);
-  free(blacklist);
+  ck_free(blacklist);
   destroy_queue();
   destroy_extras();
   ck_free(target_path);


### PR DESCRIPTION
* Prefer realloc to free + malloc and check the returned pointer for failure.
* Prefer the ck_* family of memory management functions to the ones in the standard library.
* Use syscalls for reading and writing files instead of stdio.h equivalents for consistency.
* Fix bug due to ck_free calls being duplicated.